### PR TITLE
Update matplotlib version check

### DIFF
--- a/pychemqt.py
+++ b/pychemqt.py
@@ -120,7 +120,7 @@ except ImportError as err:
     raise err
 else:
     mayor, minor, corr = map(int, matplotlib.__version__.split("."))
-    if mayor < 1 or minor < 4:
+    if mayor < 1:
         msg = QtWidgets.QApplication.translate(
             "pychemqt",
             "Your version of matplotlib is too old, you must update it.")

--- a/pychemqt.py
+++ b/pychemqt.py
@@ -120,7 +120,7 @@ except ImportError as err:
     raise err
 else:
     mayor, minor, corr = map(int, matplotlib.__version__.split("."))
-    if mayor < 1:
+    if mayor < 1 or (mayor == 1 and minor < 4):
         msg = QtWidgets.QApplication.translate(
             "pychemqt",
             "Your version of matplotlib is too old, you must update it.")


### PR DESCRIPTION
Current version of matplotlib 2.0.0 failed the proposed check.
Removed minor check so pychemqt can work with matplotlib 2.0.0